### PR TITLE
Prod Release

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,8 @@ class puppet_ent_agent::install inherits puppet_ent_agent {
   include ::puppet_ent_agent::repo
 
   case $::osfamily {
-    'AIX':     { include ::puppet_ent_agent::aix }
-    'Debian','RedHat': {
+    'AIX'    : { include ::puppet_ent_agent::aix }
+    'Debian' : { # Add RedHat when yum code works
       package { 'pe-agent':
         ensure  => $package_ensure,
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,20 +6,8 @@
 # is skipped
 class puppet_ent_agent::repo inherits puppet_ent_agent {
   case $::osfamily {
-    'RedHat': {
-      # yumrepo on PE 3.3 doesn't support proxy => _none_ - PUP-2271
-      if ($::pe_major_version == '3' and $::pe_minor_version == '3') {
-        file { '/etc/yum.repos.d/pe_repo.repo':
-          owner   => 'root',
-          group   => 'root',
-          mode    => '0644',
-          content => template("${module_name}/pe_repo.repo.erb"),
-        }
-      } else {
-        contain puppet_ent_agent::yum
-      }
-    }
     'Debian': { contain puppet_ent_agent::apt }
+    'Redhat': {} # working on yum support; note bug PUP-2271
     default:  {}
   }
 }

--- a/templates/pe_repo.repo.erb
+++ b/templates/pe_repo.repo.erb
@@ -1,4 +1,4 @@
-[puppetlabs-pepackages]
+[pe_repo]
 name=Puppet Labs PE Packages <%= @version %> - <%= @platform_tag %>
 baseurl=https://<%= @master %>:8140/packages/current/<%= @platform_tag %>
 enabled=1


### PR DESCRIPTION
*First Production Release*
- Tested AIX, Windows, and Debian/Ubuntu support with PE 3.3.1/3.3.2 agents upgrading to PE 3.7.2.
- Solaris support is untested.  
- RedHat support for PE 3.3 agents is not yet available due to bug PUP-2271.