### PR TITLE
redownload the install.bash on every upgrade

### DIFF
--- a/manifests/install/nix.pp
+++ b/manifests/install/nix.pp
@@ -24,6 +24,7 @@ class puppet_ent_agent::install::nix {
       source             => "https://${master}:8140/packages/${version}/${::platform_tag}.bash",
       destination        => "${staging_dir}/install.bash",
       timeout            => 0,
+      redownload         => true,
       verbose            => false,
       nocheckcertificate => true,
     } ->


### PR DESCRIPTION
Fixes a bug where if /tmp/${staging_dir}/install.bash
was downloaded by an eariler upgrade the later upgrade
would fail because a new install.bash upgrade file
would not be downloaded because the old one already
existed.