### PR TITLE
wget ssl fix for rhel5

### DIFF
--- a/manifests/install/nix.pp
+++ b/manifests/install/nix.pp
@@ -8,8 +8,17 @@ class puppet_ent_agent::install::nix {
 
   case $::osfamily {
     'AIX':   { $group = 'system' }
+    'Redhat': { 
+      if ($::operatingsystemmajrelease == 5) {
+        $wgetflags = ['--secure-protocol=TLSv1']
+      }
+      else {
+        $wgetflags = ''
+      }
+    }
     default: { $group = 'root' }
   }
+
 
   if (versioncmp($version,$::pe_version) > 0) {
 
@@ -26,6 +35,7 @@ class puppet_ent_agent::install::nix {
       timeout            => 0,
       redownload         => true,
       verbose            => false,
+      flags		 => $wgetflags,
       nocheckcertificate => true,
     } ->
     exec { "/bin/bash -e ${staging_dir}/install.bash":


### PR DESCRIPTION
OpenSSL on RHEL5 will try to talk to puppet server using SSLv3.
This will fail because puppet server explicitly disables this
and only permits TLS.  This commit adds a work around for
RHEL5 that will for the wget module to use the option --secure-protocol=TLSv1