### PR TITLE
2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2016-05-10 - Version 2.0.0
+
+New major version release to support classification alongside puppet_agent module during Puppet 3.x to 4.x upgrades.
+
+Bugfix:
+* params.pp: Improve agent version detection.
+* service.pp: Removed Solaris from service resource management -- puppet_agent manages the pe-puppet service during upgrades of Solaris.
+
 ## 2016-03-03 - Version 1.4.3
 
 Bugfix:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,13 +47,13 @@ class puppet_ent_agent::params {
   $manage_symlinks         = true
 
   # determine agent type
-  if $::is_pe { # PE 3.x agent
-    $bin_path     = '/opt/puppet/bin'
-    $service_name = 'pe-puppet'
-    $skip_install = false
-  } else {      # All-in-one agent
+  if versioncmp($::puppetversion, '4.0.0') > 0 { # All-in-one agent
     $bin_path     = '/opt/puppetlabs/bin'
     $service_name = 'puppet'
     $skip_install = true
+  } else {      # PE 3.x agent
+    $bin_path     = '/opt/puppet/bin'
+    $service_name = 'pe-puppet'
+    $skip_install = false
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,8 +4,10 @@ class puppet_ent_agent::service {
 
   assert_private()
 
-  service { $service_name:
-    ensure => running,
-    enable => true,
+  unless $::operatingsystem == 'Solaris' {
+    service { $service_name:
+      ensure => running,
+      enable => true,
+    }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "aharden-puppet_ent_agent",
-  "version": "1.4.3",
+  "version": "2.0.0",
   "author": "aharden",
   "summary": "Management of Puppet Enterprise agent.",
   "license": "Apache-2.0",
@@ -84,7 +84,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 3.2.0 < 2016.1.0"
+      "version_requirement": ">= 3.2.0 < 2016.2.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
## 2016-05-10 - Version 2.0.0

New major version release to support classification alongside puppet_agent module during Puppet 3.x to 4.x upgrades.

Bugfix:
- params.pp: Improve agent version detection.
- service.pp: Removed Solaris from service resource management -- puppet_agent manages the pe-puppet service during upgrades of Solaris.
